### PR TITLE
Allow library to be initialized with a reader

### DIFF
--- a/browscap.go
+++ b/browscap.go
@@ -44,17 +44,17 @@ func InitBrowsCap(path string, force bool) error {
 }
 
 func InitBrowsCapFromReader(reader *bufio.Reader) error {
-    if initialized {
-        return nil
-    }
-    var err error
+	if initialized {
+		return nil
+	}
+	var err error
 
-    if dict, err = loadFromReader(reader); err != nil {
-        return fmt.Errorf("browscap: An error occurred while loading from reader, %v ", err)
-    }
+	if dict, err = loadFromReader(reader); err != nil {
+		return fmt.Errorf("browscap: An error occurred while loading from reader, %v ", err)
+	}
 
-    initialized = true
-    return nil
+	initialized = true
+	return nil
 }
 
 func InitializedVersion() string {

--- a/browscap.go
+++ b/browscap.go
@@ -43,8 +43,8 @@ func InitBrowsCap(path string, force bool) error {
 	return nil
 }
 
-func InitBrowsCapFromReader(reader *bufio.Reader) error {
-	if initialized {
+func InitBrowsCapFromReader(reader *bufio.Reader, force bool) error {
+	if initialized && !force {
 		return nil
 	}
 	var err error

--- a/browscap.go
+++ b/browscap.go
@@ -4,7 +4,7 @@
 package browscap_go
 
 import (
-    "bufio"
+	"bufio"
 	"fmt"
 	"io/ioutil"
 	"net/http"

--- a/browscap.go
+++ b/browscap.go
@@ -4,6 +4,7 @@
 package browscap_go
 
 import (
+    "bufio"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -40,6 +41,20 @@ func InitBrowsCap(path string, force bool) error {
 
 	initialized = true
 	return nil
+}
+
+func InitBrowsCapFromReader(reader *bufio.Reader) error {
+    if initialized {
+        return nil
+    }
+    var err error
+
+    if dict, err = loadFromReader(reader); err != nil {
+        return fmt.Errorf("browscap: An error occurred while loading from reader, %v ", err)
+    }
+
+    initialized = true
+    return nil
 }
 
 func InitializedVersion() string {

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -4,6 +4,8 @@
 package browscap_go
 
 import (
+    "bufio"
+    "bytes"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -19,6 +21,20 @@ func TestInitBrowsCap(t *testing.T) {
 	if err := InitBrowsCap(TEST_INI_FILE, false); err != nil {
 		t.Fatalf("%v", err)
 	}
+}
+
+func TestInitBrowsCapFromReader(t *testing.T) {
+    buffer, err := ioutil.ReadFile(TEST_INI_FILE)
+    if err != nil {
+        t.Fatalf("%v", err)
+    }
+
+    reader := bytes.NewReader(buffer)
+    buf := bufio.NewReader(reader)
+
+    if err := InitBrowsCapFromReader(buf); err != nil {
+        t.Fatalf("%v", err)
+    }
 }
 
 func TestGetBrowser(t *testing.T) {

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 func initFromTestIniFile(t *testing.T) {
-	if err := InitBrowsCap(TEST_INI_FILE, true); err != nil {
+	if err := InitBrowsCap(TEST_INI_FILE, false); err != nil {
 		t.Fatalf("%v", err)
 	}
 }

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -23,6 +23,12 @@ func initFromTestIniFile(t *testing.T) {
 	}
 }
 
+func TestInitBrowsCap(t *testing.T) {
+	if err := InitBrowsCap(TEST_INI_FILE, true); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
 func TestInitBrowsCapFromReader(t *testing.T) {
 	file, err := os.Open(TEST_INI_FILE)
 	if err != nil {
@@ -149,6 +155,10 @@ func BenchmarkInit(b *testing.B) {
 }
 
 func BenchmarkGetBrowser(b *testing.B) {
+	if err := InitBrowsCap(TEST_INI_FILE, false); err != nil {
+		b.Fatalf("%v", err)
+	}
+	
 	data, err := ioutil.ReadFile("test-data/user_agents_sample.txt")
 	if err != nil {
 		b.Error(err)

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -32,7 +32,7 @@ func TestInitBrowsCapFromReader(t *testing.T) {
 	reader := bytes.NewReader(buffer)
 	buf := bufio.NewReader(reader)
 
-	if err := InitBrowsCapFromReader(buf); err != nil {
+	if err := InitBrowsCapFromReader(buf, false); err != nil {
 		t.Fatalf("%v", err)
 	}
 }

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -5,10 +5,10 @@ package browscap_go
 
 import (
 	"bufio"
-	"bytes"
 	"io/ioutil"
 	"strings"
 	"testing"
+	"os"
 )
 
 const (
@@ -24,13 +24,13 @@ func TestInitBrowsCap(t *testing.T) {
 }
 
 func TestInitBrowsCapFromReader(t *testing.T) {
-	buffer, err := ioutil.ReadFile(TEST_INI_FILE)
+	file, err := os.Open(TEST_INI_FILE)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
+	defer file.Close()
 
-	reader := bytes.NewReader(buffer)
-	buf := bufio.NewReader(reader)
+	buf := bufio.NewReader(file)
 
 	if err := InitBrowsCapFromReader(buf, false); err != nil {
 		t.Fatalf("%v", err)

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -17,8 +17,8 @@ const (
 	TEST_IPHONE_AGENT = "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5"
 )
 
-func TestInitBrowsCap(t *testing.T) {
-	if err := InitBrowsCap(TEST_INI_FILE, false); err != nil {
+func initFromTestIniFile(t *testing.T) {
+	if err := InitBrowsCap(TEST_INI_FILE, true); err != nil {
 		t.Fatalf("%v", err)
 	}
 }
@@ -32,12 +32,13 @@ func TestInitBrowsCapFromReader(t *testing.T) {
 
 	buf := bufio.NewReader(file)
 
-	if err := InitBrowsCapFromReader(buf, false); err != nil {
+	if err := InitBrowsCapFromReader(buf, true); err != nil {
 		t.Fatalf("%v", err)
 	}
 }
 
 func TestGetBrowser(t *testing.T) {
+	initFromTestIniFile(t)
 	if browser, ok := GetBrowser(TEST_USER_AGENT); !ok {
 		t.Error("Browser not found")
 	} else if browser.Browser != "Chrome" {
@@ -54,6 +55,7 @@ func TestGetBrowser(t *testing.T) {
 }
 
 func TestGetBrowserIPhone(t *testing.T) {
+	initFromTestIniFile(t)
 	if browser, ok := GetBrowser(TEST_IPHONE_AGENT); !ok {
 		t.Error("Browser not found")
 	} else if browser.DeviceName != "iPhone" {
@@ -68,6 +70,7 @@ func TestGetBrowserIPhone(t *testing.T) {
 }
 
 func TestGetBrowserYandex(t *testing.T) {
+	initFromTestIniFile(t)
 	if browser, ok := GetBrowser("Yandex Browser 1.1"); !ok {
 		t.Error("Browser not found")
 	} else if browser.Browser != "Yandex Browser" {
@@ -77,6 +80,7 @@ func TestGetBrowserYandex(t *testing.T) {
 	}
 }
 func TestGetBrowser360Spider(t *testing.T) {
+	initFromTestIniFile(t)
 	if browser, ok := GetBrowser("360Spider"); !ok {
 		t.Error("Browser not found")
 	} else if browser.Browser != "360Spider" {
@@ -87,6 +91,7 @@ func TestGetBrowser360Spider(t *testing.T) {
 }
 
 func TestGetBrowserIssues(t *testing.T) {
+	initFromTestIniFile(t)
 	// https://github.com/digitalcrab/browscap_go/issues/4
 	ua := "Mozilla/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3"
 	if browser, ok := GetBrowser(ua); !ok {
@@ -95,6 +100,7 @@ func TestGetBrowserIssues(t *testing.T) {
 		t.Errorf("Expected tablet %q", browser.DeviceType)
 	}
 }
+
 func TestLastVersion(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -4,8 +4,8 @@
 package browscap_go
 
 import (
-    "bufio"
-    "bytes"
+	"bufio"
+	"bytes"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -24,17 +24,17 @@ func TestInitBrowsCap(t *testing.T) {
 }
 
 func TestInitBrowsCapFromReader(t *testing.T) {
-    buffer, err := ioutil.ReadFile(TEST_INI_FILE)
-    if err != nil {
-        t.Fatalf("%v", err)
-    }
+	buffer, err := ioutil.ReadFile(TEST_INI_FILE)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
-    reader := bytes.NewReader(buffer)
-    buf := bufio.NewReader(reader)
+	reader := bytes.NewReader(buffer)
+	buf := bufio.NewReader(reader)
 
-    if err := InitBrowsCapFromReader(buf); err != nil {
-        t.Fatalf("%v", err)
-    }
+	if err := InitBrowsCapFromReader(buf); err != nil {
+		t.Fatalf("%v", err)
+	}
 }
 
 func TestGetBrowser(t *testing.T) {

--- a/loader.go
+++ b/loader.go
@@ -34,7 +34,7 @@ func loadFromIniFile(path string) (*dictionary, error) {
 
 	buf := bufio.NewReader(file)
 
-    return loadFromReader(buf)
+	return loadFromReader(buf)
 }
 
 func loadFromReader(buf *bufio.Reader) (*dictionary, error) {

--- a/loader.go
+++ b/loader.go
@@ -32,9 +32,14 @@ func loadFromIniFile(path string) (*dictionary, error) {
 	}
 	defer file.Close()
 
+	buf := bufio.NewReader(file)
+
+    return loadFromReader(buf)
+}
+
+func loadFromReader(buf *bufio.Reader) (*dictionary, error) {
 	dict := newDictionary()
 
-	buf := bufio.NewReader(file)
 	sectionName := ""
 
 	lineNum := 0


### PR DESCRIPTION
Add an option to initialize the browscap library with a `Reader`. This is needed when an embedded asset is used, e.g. when using `go-bindata`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/browscap_go/1)
<!-- Reviewable:end -->
