### PR TITLE
Refactor tests

### DIFF
--- a/browscap_test.go
+++ b/browscap_test.go
@@ -19,7 +19,7 @@ const (
 
 func initFromTestIniFile(tb testing.TB) {
 	if err := InitBrowsCap(TEST_INI_FILE, false); err != nil {
-	tb.Fatalf("%v", err)
+		tb.Fatalf("%v", err)
 	}
 }
 

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -17,9 +17,9 @@ const (
 	TEST_IPHONE_AGENT = "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5"
 )
 
-func initFromTestIniFile(t *testing.T) {
+func initFromTestIniFile(tb testing.TB) {
 	if err := InitBrowsCap(TEST_INI_FILE, false); err != nil {
-		t.Fatalf("%v", err)
+	tb.Fatalf("%v", err)
 	}
 }
 
@@ -155,9 +155,7 @@ func BenchmarkInit(b *testing.B) {
 }
 
 func BenchmarkGetBrowser(b *testing.B) {
-	if err := InitBrowsCap(TEST_INI_FILE, false); err != nil {
-		b.Fatalf("%v", err)
-	}
+	initFromTestIniFile(b)
 	
 	data, err := ioutil.ReadFile("test-data/user_agents_sample.txt")
 	if err != nil {


### PR DESCRIPTION
Use `testing.TB` interface so that we can reuse `initFromTestFile()` in `BenchmarkGetBrowser()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/browscap_go/2)
<!-- Reviewable:end -->
